### PR TITLE
Added support for src in recipes tag

### DIFF
--- a/afmlTags.js
+++ b/afmlTags.js
@@ -495,26 +495,46 @@ class AFMLToolStats extends HTMLElement {
 customElements.define("a-tool", AFMLToolStats);
 
 class AFMLRecipes extends HTMLElement {
+	static observedAttributes = ["src"];
 	constructor() {
 		// Always call super first in constructor
 		super();
 	}
 	connectedCallback(){
-		let contents = this.innerHTML.trim();
-		if (!contents.startsWith('{') && !contents.startsWith('[')) return;
-		let sections = eval('['+contents+']');
-		this.textContent = '';
-		let table = this.createChild('table', '', ['class', 'recipetable'], ['cellspacing', '0']);
-		let head = table.createChild('thead');
-		let row = head.createChild('tr');
-		row.createChild('th', 'Result');
-		row.createChild('th', 'Ingredients', ['class', 'middle']);
-		row.createChild('th').createChild('a', 'Crafting Station', ['href', 'https://terraria.wiki.gg/wiki/Crafting_stations']);
-
-		let body = table.createChild('tbody');
-		for(let j = 0; j < sections.length; j++){
-			this.processRecipeBlock(sections[j], body);
+		if (!this.hasAttribute('src')) {
+			let contents = this.innerHTML.trim();
+			if (!contents.startsWith('{') && !contents.startsWith('[')) return;
+			let sections = eval('['+contents+']');
+			this.textContent = '';
+			let table = this.createChild('table', '', ['class', 'recipetable'], ['cellspacing', '0']);
+			let head = table.createChild('thead');
+			let row = head.createChild('tr');
+			row.createChild('th', 'Result');
+			row.createChild('th', 'Ingredients', ['class', 'middle']);
+			row.createChild('th').createChild('a', 'Crafting Station', ['href', 'https://terraria.wiki.gg/wiki/Crafting_stations']);
+			
+			let body = table.createChild('tbody');
+			for(let j = 0; j < sections.length; j++){
+				this.processRecipeBlock(sections[j], body);
+			}
 		}
+	}
+	attributeChangedCallback(name, oldValue, newValue) {
+		getStats(newValue.replace(' ', '_')).then((value) => {
+			let sections = this.hasAttribute('usedIn') ? value.UsedIn : value.Recipes;
+			this.textContent = '';
+			let table = this.createChild('table', '', ['class', 'recipetable'], ['cellspacing', '0']);
+			let head = table.createChild('thead');
+			let row = head.createChild('tr');
+			row.createChild('th', 'Result');
+			row.createChild('th', 'Ingredients', ['class', 'middle']);
+			row.createChild('th').createChild('a', 'Crafting Station', ['href', 'https://terraria.wiki.gg/wiki/Crafting_stations']);
+			
+			let body = table.createChild('tbody');
+			for (let i = 0; i < sections.length; i++) {
+				this.processRecipeBlock(sections[i], body);
+			}
+		});
 	}
 	processRecipeBlock(data, body){
 		let stations = '<a href="https://terraria.wiki.gg/wiki/By_Hand">By Hand</a>';

--- a/afmlTags.js
+++ b/afmlTags.js
@@ -520,21 +520,23 @@ class AFMLRecipes extends HTMLElement {
 		}
 	}
 	attributeChangedCallback(name, oldValue, newValue) {
-		getStats(newValue.replace(' ', '_')).then((value) => {
-			let sections = this.hasAttribute('usedIn') ? value.UsedIn : value.Recipes;
-			this.textContent = '';
-			let table = this.createChild('table', '', ['class', 'recipetable'], ['cellspacing', '0']);
-			let head = table.createChild('thead');
-			let row = head.createChild('tr');
-			row.createChild('th', 'Result');
-			row.createChild('th', 'Ingredients', ['class', 'middle']);
-			row.createChild('th').createChild('a', 'Crafting Station', ['href', 'https://terraria.wiki.gg/wiki/Crafting_stations']);
-			
-			let body = table.createChild('tbody');
-			for (let i = 0; i < sections.length; i++) {
-				this.processRecipeBlock(sections[i], body);
-			}
-		});
+		if (name === 'src') {
+			getStats(newValue.replace(' ', '_')).then((value) => {
+				let sections = this.hasAttribute('usedIn') ? value.UsedIn : value.Recipes;
+				this.textContent = '';
+				let table = this.createChild('table', '', ['class', 'recipetable'], ['cellspacing', '0']);
+				let head = table.createChild('thead');
+				let row = head.createChild('tr');
+				row.createChild('th', 'Result');
+				row.createChild('th', 'Ingredients', ['class', 'middle']);
+				row.createChild('th').createChild('a', 'Crafting Station', ['href', 'https://terraria.wiki.gg/wiki/Crafting_stations']);
+				
+				let body = table.createChild('tbody');
+				for (let i = 0; i < sections.length; i++) {
+					this.processRecipeBlock(sections[i], body);
+				}
+			});
+		}
 	}
 	processRecipeBlock(data, body){
 		let stations = '<a href="https://terraria.wiki.gg/wiki/By_Hand">By Hand</a>';


### PR DESCRIPTION
`<a-recipes>` tags can now utilize the `src` and `usedIn` attributes to pull recipe information from json files. The existing functionality is still maintained if the `src` attribute is omitted.
### Example usage

- `<a-recipes src="Air_Tank"></a-recipes>` - shows all the recipes where the result is the `Air Tank`
- `<a-recipes src="Air_Tank" usedIn></a-recipes>` - shows all the recipes that include the `Air Tank`